### PR TITLE
Wrong index to make custom arrow be disabled

### DIFF
--- a/src/custom-arrows.js
+++ b/src/custom-arrows.js
@@ -50,14 +50,14 @@ export function initCustomArrows(flkty, options){
 }
 
 /**
- * Get is-selected position
- * return 0 - first index
+ * Get slide position
+ * return 0 - first slide
  * return 1 - last index
- * return -1 - not first/last index
+ * return -1 - not first/last position
  * @param flkty
  * @return number
  */
-function getIsSelectedPosition(flkty){
+function getSlidePosition(flkty){
     const {selectedIndex, slides} = flkty;
     if(selectedIndex === 0) return 0;
     if(selectedIndex === slides.length - 1) return 1;
@@ -75,13 +75,13 @@ function updateCustomArrowsDisableStatus(flkty, options){
     const prevArrow = options.customArrows.prevArrow.el;
     const nextArrow = options.customArrows.nextArrow.el;
 
-    const index = getIsSelectedPosition(flkty);
+    const slidePosition = getSlidePosition(flkty);
 
-    if(index === 0){
+    if(slidePosition === 0){
         // disable prev button
         prevArrow.setAttribute('disabled', 'disabled');
         nextArrow.removeAttribute('disabled');
-    }else if(index === 1){
+    }else if(slidePosition === 1){
         // disable next prev button
         nextArrow.setAttribute('disabled', 'disabled');
         prevArrow.removeAttribute('disabled');

--- a/src/custom-arrows.js
+++ b/src/custom-arrows.js
@@ -58,9 +58,9 @@ export function initCustomArrows(flkty, options){
  * @return number
  */
 function getIsSelectedPosition(flkty){
-    const {cells} = flkty;
-    if(cells[0].element.classList.contains('is-selected')) return 0;
-    if(cells.slice(-1)[0].element.classList.contains('is-selected')) return 1;
+    const {selectedIndex, slides} = flkty;
+    if(selectedIndex === 0) return 0;
+    if(selectedIndex === slides.length - 1) return 1;
     return -1;
 }
 

--- a/src/custom-arrows.js
+++ b/src/custom-arrows.js
@@ -49,6 +49,20 @@ export function initCustomArrows(flkty, options){
     }
 }
 
+/**
+ * Get is-selected position
+ * return 0 - first index
+ * return 1 - last index
+ * return -1 - not first/last index
+ * @param flkty
+ * @return number
+ */
+function getIsSelectedPosition(flkty){
+    const {cells} = flkty;
+    if(cells[0].element.classList.contains('is-selected')) return 0;
+    if(cells.slice(-1)[0].element.classList.contains('is-selected')) return 1;
+    return -1;
+}
 
 /**
  * Update disable status
@@ -58,15 +72,16 @@ export function initCustomArrows(flkty, options){
 function updateCustomArrowsDisableStatus(flkty, options){
     // no disabled status if is wrapAround (infinite)
     if(options.isInfinite) return;
-    const index = flkty.selectedIndex;
     const prevArrow = options.customArrows.prevArrow.el;
     const nextArrow = options.customArrows.nextArrow.el;
+
+    const index = getIsSelectedPosition(flkty);
 
     if(index === 0){
         // disable prev button
         prevArrow.setAttribute('disabled', 'disabled');
         nextArrow.removeAttribute('disabled');
-    }else if(index === flkty.cells.length - 1){
+    }else if(index === 1){
         // disable next prev button
         nextArrow.setAttribute('disabled', 'disabled');
         prevArrow.removeAttribute('disabled');


### PR DESCRIPTION
## Fix a bug: Wrong index

With old code, we check the current index of the slide based on input (just a number, similar to the index of `change` event).

But that's the wrong index (what happens when we change the `groupCells` of `flkty` to another, different to `1`) and `selectedIndex` is just a `number`, but `is-selected` in `DOM` is more than 1. So I think that the `selectedIndex` that we used is just a current index of `flickity dots` (fix me if I'm wrong because I haven't read the flkty source code before).

So I have made a little change to make it work based on the `is-selected` position. Please check it! Many thanks.