### PR TITLE
Flickity responsive > enhance wrap around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v2.0.3 - 2023-01-13
+
+- Validate wrapAround option
+
 ### v2.0.2 - 2022-11-18
 
 - Fix bug detect first/last slide to disable prev/next button.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,7 +42,7 @@ export function init(el, object, flickityOptions){
  * @param wrapper
  * @returns boolean
  */
-export function validateWrapAround(flickity, wrapper){
+export function validateWrapAround(flickity, wrapper = null){
     if(flickity){
         const totalCellWidth = flickity.cells.reduce((acc, cell) => acc + cell.size.width, 0);
         return Math.round(flickity.size.width) > Math.round(totalCellWidth);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -32,3 +32,17 @@ export function init(el, object, flickityOptions){
 
     return true;
 }
+
+
+/**
+ * Has wrap-around options
+ * @param flickity
+ * @param wrapper
+ * @returns boolean
+ */
+export function hasWrapAround(flickity, wrapper){
+    if(flickity) return Math.round(flickity.size.width) > Math.round(flickity.cells.reduce((acc, cell) => acc + cell.size.width, 0));
+
+    const totalWidth = Math.round([...wrapper.children].reduce((acc, node) => acc + node.getBoundingClientRect().width, 0));
+    return Math.round(wrapper.getBoundingClientRect().width) > totalWidth;
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,6 @@ import {MatchMediaScreen} from "match-media-screen";
 import {onMatched} from "./on-matched";
 import {onResize} from "./on-resize";
 import {onLoad} from "./on-load";
-import {isjQueryElement} from "@/utils";
 
 /**
  * Init Flickity Responsive

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,6 +2,7 @@ import {MatchMediaScreen} from "match-media-screen";
 import {onMatched} from "./on-matched";
 import {onResize} from "./on-resize";
 import {onLoad} from "./on-load";
+import {isjQueryElement} from "@/utils";
 
 /**
  * Init Flickity Responsive
@@ -35,14 +36,18 @@ export function init(el, object, flickityOptions){
 
 
 /**
- * Has wrap-around options
+ * Validate wrapAround option
+ * Compare value between the total item width and viewport width
  * @param flickity
  * @param wrapper
  * @returns boolean
  */
-export function hasWrapAround(flickity, wrapper){
-    if(flickity) return Math.round(flickity.size.width) > Math.round(flickity.cells.reduce((acc, cell) => acc + cell.size.width, 0));
+export function validateWrapAround(flickity, wrapper){
+    if(flickity){
+        const totalCellWidth = flickity.cells.reduce((acc, cell) => acc + cell.size.width, 0);
+        return Math.round(flickity.size.width) > Math.round(totalCellWidth);
+    }
 
-    const totalWidth = Math.round([...wrapper.children].reduce((acc, node) => acc + node.getBoundingClientRect().width, 0));
-    return Math.round(wrapper.getBoundingClientRect().width) > totalWidth;
+    const totalCellWidth = [...wrapper.children].reduce((acc, node) => acc + node.getBoundingClientRect().width, 0);
+    return Math.round(wrapper.getBoundingClientRect().width) > Math.round(totalCellWidth);
 }

--- a/src/on-load.js
+++ b/src/on-load.js
@@ -1,6 +1,6 @@
 import {initSlidesIndicator} from "./slides-indicator";
 import {responsiveNavigation} from "./responsive-navigation";
-import {validateWrapAround} from "@/helpers";
+import {validateWrapAround} from "./helpers";
 
 export function onLoad(el, options){
     let flkty = Flickity.data(el);

--- a/src/on-load.js
+++ b/src/on-load.js
@@ -6,8 +6,9 @@ export function onLoad(el, options){
     let flkty = Flickity.data(el);
     if(!flkty) return;
 
-    if(options.object?.wrapAround)
+    if(options.object?.wrapAround){
         options.object.wrapAround = validateWrapAround(flkty);
+    }
 
     // responsive navigation
     responsiveNavigation(flkty, options);

--- a/src/on-load.js
+++ b/src/on-load.js
@@ -1,13 +1,13 @@
 import {initSlidesIndicator} from "./slides-indicator";
 import {responsiveNavigation} from "./responsive-navigation";
-import {hasWrapAround} from "@/helpers";
+import {validateWrapAround} from "@/helpers";
 
 export function onLoad(el, options){
     let flkty = Flickity.data(el);
     if(!flkty) return;
 
     if(options.object?.wrapAround)
-        options.object.wrapAround = hasWrapAround(flkty);
+        options.object.wrapAround = validateWrapAround(flkty);
 
     // responsive navigation
     responsiveNavigation(flkty, options);

--- a/src/on-load.js
+++ b/src/on-load.js
@@ -1,9 +1,13 @@
 import {initSlidesIndicator} from "./slides-indicator";
 import {responsiveNavigation} from "./responsive-navigation";
+import {hasWrapAround} from "@/helpers";
 
 export function onLoad(el, options){
     let flkty = Flickity.data(el);
     if(!flkty) return;
+
+    if(options.object?.wrapAround)
+        options.object.wrapAround = hasWrapAround(flkty);
 
     // responsive navigation
     responsiveNavigation(flkty, options);

--- a/src/on-matched.js
+++ b/src/on-matched.js
@@ -1,6 +1,6 @@
 import {initCustomArrows} from "./custom-arrows";
 import {initSlidesIndicator} from "./slides-indicator";
-import {validateWrapAround} from "@/helpers";
+import {validateWrapAround} from "./helpers";
 
 export function onMatched(el, options){
     // get instance

--- a/src/on-matched.js
+++ b/src/on-matched.js
@@ -1,5 +1,6 @@
 import {initCustomArrows} from "./custom-arrows";
 import {initSlidesIndicator} from "./slides-indicator";
+import {hasWrapAround} from "@/helpers";
 
 export function onMatched(el, options){
     // get instance
@@ -18,6 +19,16 @@ export function onMatched(el, options){
     /** Before Init **/
 
     /** Init **/
+    if(options.wrapAround){
+        if(!flkty){
+            const wrapper = document.querySelector(el);
+            options.wrapAround = hasWrapAround(false, wrapper);
+
+        }else{
+            options.wrapAround = hasWrapAround(flkty);
+        }
+    }
+
     // init new instance
     flkty = new Flickity(el, options);
 

--- a/src/on-matched.js
+++ b/src/on-matched.js
@@ -1,6 +1,6 @@
 import {initCustomArrows} from "./custom-arrows";
 import {initSlidesIndicator} from "./slides-indicator";
-import {hasWrapAround} from "@/helpers";
+import {validateWrapAround} from "@/helpers";
 
 export function onMatched(el, options){
     // get instance
@@ -22,10 +22,10 @@ export function onMatched(el, options){
     if(options.wrapAround){
         if(!flkty){
             const wrapper = document.querySelector(el);
-            options.wrapAround = hasWrapAround(false, wrapper);
+            options.wrapAround = validateWrapAround(false, wrapper);
 
         }else{
-            options.wrapAround = hasWrapAround(flkty);
+            options.wrapAround = validateWrapAround(flkty);
         }
     }
 

--- a/src/on-resize.js
+++ b/src/on-resize.js
@@ -1,5 +1,5 @@
 import {responsiveNavigation} from "./responsive-navigation";
-import {hasWrapAround} from "@/helpers";
+import {validateWrapAround} from "@/helpers";
 
 export function onResize(el, options){
     let flkty = Flickity.data(el);
@@ -10,6 +10,6 @@ export function onResize(el, options){
 
     // check the wrapAround
     if(options.wrapAround){
-        flkty.options.wrapAround = hasWrapAround(flkty);
+        flkty.options.wrapAround = validateWrapAround(flkty);
     }
 }

--- a/src/on-resize.js
+++ b/src/on-resize.js
@@ -1,4 +1,5 @@
 import {responsiveNavigation} from "./responsive-navigation";
+import {hasWrapAround} from "@/helpers";
 
 export function onResize(el, options){
     let flkty = Flickity.data(el);
@@ -6,4 +7,9 @@ export function onResize(el, options){
 
     // responsive navigation
     responsiveNavigation(flkty, options);
+
+    // check the wrapAround
+    if(options.wrapAround){
+        flkty.options.wrapAround = hasWrapAround(flkty);
+    }
 }

--- a/src/on-resize.js
+++ b/src/on-resize.js
@@ -1,5 +1,5 @@
 import {responsiveNavigation} from "./responsive-navigation";
-import {validateWrapAround} from "@/helpers";
+import {validateWrapAround} from "./helpers";
 
 export function onResize(el, options){
     let flkty = Flickity.data(el);


### PR DESCRIPTION
## Validating `wrapAround` option, 

Whenever we add this option to Flickity, we have to check it again, because sometimes the total items may be smaller than the viewport wrapper.

### Without validating the `wrapAround` option

![ezgif-3-fd6e504fc5](https://user-images.githubusercontent.com/30406982/212277797-f74a4f35-a97b-4fe5-9f3c-82fdfbcc2788.gif)

### With validating the `wrapAround` option

![ezgif-3-2f94ac6ad4](https://user-images.githubusercontent.com/30406982/212278003-6d1c52b9-7651-48e2-bc0a-13821a73bc8f.gif)

