### PR TITLE
Change the property to get the real DOM elements

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,7 +28,7 @@ export function init(el, object, flickityOptions){
 
 
     // on load
-    onLoad(el, {...flickityOptions, object});
+    onLoad(el, {...flickityOptions, ...object});
 
     return true;
 }
@@ -38,7 +38,6 @@ export function init(el, object, flickityOptions){
  * Validate wrapAround option
  * Compare value between the total item width and viewport width
  * @param flickity
- * @param wrapper
  * @returns boolean
  */
 export function validateWrapAround(flickity){

--- a/src/on-matched.js
+++ b/src/on-matched.js
@@ -31,7 +31,7 @@ export function onMatched(el, options){
     }
 
     /** After Init **/
-    options.isInfinite = options.hasOwnProperty('wrapAround') && options.wrapAround;
+    options.isInfinite = options.hasOwnProperty('wrapAround') && flkty.options.wrapAround;
 
     if(flkty.options.autoAdjustPosition){
         // select begin position

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -3,11 +3,19 @@
  * @param flkty
  * @param options
  */
+import {isjQueryElement} from "@/utils";
+
 export function responsiveNavigation(flkty, options){
     if(options.responsiveNavigation !== true) return;
 
     const elements = [
         flkty.pageDots ? flkty.pageDots.holder : undefined,
+        options.prevArrow ?? undefined,
+        options.nextArrow ?? undefined,
+        options.indicatorCurrent ?? undefined,
+        options.indicatorTotal ?? undefined,
+
+        // Property from old code, should to check it again because I don't know what's this purpose?
         flkty.prevButton ? flkty.prevButton.element : undefined,
         flkty.nextButton ? flkty.nextButton.element : undefined,
         options.customArrows ? options.customArrows.prevArrow.el : undefined,
@@ -18,6 +26,12 @@ export function responsiveNavigation(flkty, options){
 
     elements.forEach(el => {
         if(!el || typeof el !== 'object') return;
+
+        // jQuery element
+        if(isjQueryElement(el)){
+            el = el[0];
+        }
+
         if(isSlideable){
             el.classList.remove(options._class.buttonFreeze);
             el.style.display = '';


### PR DESCRIPTION
In the previous version, we used the wrong property to get DOM Elements. But I think the problem that led our library to the bug is the way we pass the options parameter (it's different between `onMatched` and `onResize` events)

![image](https://user-images.githubusercontent.com/30406982/220859014-588e95cb-4277-4d0a-a531-553e434dd84b.png)