### PR TITLE
Custom arrows > wrong condition cause a bug 

### DIFF
--- a/src/custom-arrows.js
+++ b/src/custom-arrows.js
@@ -90,11 +90,11 @@ export function updateCustomArrowsDisableStatus(flkty, options){
 
     const slidePosition = getSlidePosition(flkty);
 
-    if(slidePosition === 0 || selectedCellIndex === adjustedBeginIndex){
+    if(slidePosition === 0 || (selectedCellIndex === adjustedBeginIndex && selectedCellIndex !== -1)){
         // disable prev button
         prevArrow.setAttribute('disabled', 'disabled');
         nextArrow.removeAttribute('disabled');
-    }else if(slidePosition === 1 || selectedCellIndex === adjustedEndIndex){
+    }else if(slidePosition === 1 || (selectedCellIndex === adjustedEndIndex && selectedCellIndex !== -1)){
         // disable next prev button
         nextArrow.setAttribute('disabled', 'disabled');
         prevArrow.removeAttribute('disabled');


### PR DESCRIPTION
I put the wrong condition here, we have declared 3 variables and assigned the default value for them ( `adjustedBeginIndex`, `adjustedEndIndex`, `selectedCellIndex`). But in the condition to set the `disabled` attribute for each arrow, I compared the dummy condition (slidePosition === 0 || selectedCellIndex === adjustedBeginIndex), and it always runs this code.