### PR TITLE
Fix is slider can slide

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -113,6 +113,32 @@ jQuery('.carousel-2').flickityResponsive({
     <section class="mb100">
         <p style="margin-bottom:0;"><span class="extra-feature">Extra feature</span></p>
         <div class="d-flex jc-space-between ai-center">
+            <h2>Responsive navigation</h2>
+        </div>
+        <p>Automatically detect whether the slider is slide-able or not on load and resize.
+            If the slider is not slide-able, the navigation elements will be hidden, draggable will be disabled.
+        </p>
+        <div class="d-flex jc-space-between ai-center"></div>
+        <div data-flickity-responsive>
+            <div class="carousel-cell" style="min-width:250px;"></div>
+            <div class="carousel-cell" style="min-width:250px;"></div>
+            <div class="carousel-cell" style="min-width:250px;"></div>
+        </div>
+
+        <details>
+            <summary>View code</summary>
+            <pre>
+// custom arrows
+const carouselArrows = new FlickityResponsive('.carousel-arrows', {
+    responsiveNavigation: true, // true by default
+});</pre>
+        </details>
+    </section>
+
+
+    <section class="mb100">
+        <p style="margin-bottom:0;"><span class="extra-feature">Extra feature</span></p>
+        <div class="d-flex jc-space-between ai-center">
             <h2>Custom arrows and indicator numbers</h2>
         </div>
         <p>Use <code>prevArrow</code> and <code>nextArrow</code> to assign custom prev/next buttons.</p>

--- a/dev/style.scss
+++ b/dev/style.scss
@@ -1,10 +1,14 @@
 .carousel-cell {
   width: calc(33.33% - 20px / 3);
   height: 200px;
-  margin-right: 10px;
+
   background: #8C8;
   border-radius: 5px;
   counter-increment: carousel-cell;
+}
+
+.carousel-cell:not(:last-child) {
+  margin-right: 10px;
 }
 
 /* cell number */

--- a/src/_index.js
+++ b/src/_index.js
@@ -24,6 +24,7 @@ const defaultFlickityOptions = {
     _class: {
         buttonFreeze: 'flickity-button-freeze',
         isForceMove: 'is-force-move',
+        isCannotSlide: 'is-cannot-slide'
     }
 };
 

--- a/src/_index.js
+++ b/src/_index.js
@@ -22,7 +22,7 @@ const defaultFlickityOptions = {
     forceMove: true,
 
     _class: {
-        buttonFreeze: 'flickity-button-freeze',
+        isFreeze: 'is-freeze', // for navigation buttons (prev, next, custom arrows, dots)
         isForceMove: 'is-force-move',
         isCannotSlide: 'is-cannot-slide'
     }

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -14,7 +14,9 @@ export function responsiveNavigation(flkty, options){
         flkty.options.customArrows ? flkty.options.customArrows.nextArrow.el : undefined
     ];
 
-    const isSlideable = flkty.slideableWidth > flkty.size.innerWidth;
+    const slideableWidth = Math.round(flkty.slideableWidth);
+    const innerWidth = Math.round(flkty.size.innerWidth);
+    const isSlideable = slideableWidth > innerWidth;
 
     elements.forEach(el => {
         if(!el || typeof el !== 'object') return;

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -18,18 +18,20 @@ export function responsiveNavigation(flkty, options){
     const innerWidth = Math.round(flkty.size.innerWidth);
     const isSlideable = slideableWidth > innerWidth;
 
+    // loop through the elements and hide them if the slider is not slide-able
     elements.forEach(el => {
         if(!el || typeof el !== 'object') return;
         if(isSlideable){
-            el.classList.remove(options._class.buttonFreeze);
+            el.classList.remove(options._class.isFreeze);
             el.style.display = '';
         }else{
-            el.classList.add(options._class.buttonFreeze);
+            el.classList.add(options._class.isFreeze);
             el.style.display = 'none';
         }
     });
 
 
+    // add class to the element if the slider is not slide-able
     if(isSlideable){
         // remove class from the element
         flkty.element.classList.remove(options._class.isCannotSlide);

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -28,4 +28,10 @@ export function responsiveNavigation(flkty, options){
             el.style.display = 'none';
         }
     });
+
+
+    if(isSlideable){
+        // add class to the element
+        flkty.element.classList.add(options._class.isCannotSlide);
+    }
 }

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -31,10 +31,10 @@ export function responsiveNavigation(flkty, options){
 
 
     if(isSlideable){
-        // add class to the element
-        flkty.element.classList.add(options._class.isCannotSlide);
-    }else{
         // remove class from the element
         flkty.element.classList.remove(options._class.isCannotSlide);
+    }else{
+        // add class from the element
+        flkty.element.classList.add(options._class.isCannotSlide);
     }
 }

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -39,4 +39,8 @@ export function responsiveNavigation(flkty, options){
         // add class from the element
         flkty.element.classList.add(options._class.isCannotSlide);
     }
+
+    // draggable
+    flkty.options.draggable = isSlideable;
+    flkty.updateDraggable();
 }

--- a/src/responsive-navigation.js
+++ b/src/responsive-navigation.js
@@ -33,5 +33,8 @@ export function responsiveNavigation(flkty, options){
     if(isSlideable){
         // add class to the element
         flkty.element.classList.add(options._class.isCannotSlide);
+    }else{
+        // remove class from the element
+        flkty.element.classList.remove(options._class.isCannotSlide);
     }
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the responsive navigation feature, along with some style adjustments and code refactoring. The key changes include the addition of new HTML sections, updates to CSS styles, modifications to JavaScript options, and improvements to the responsive navigation logic.

### Enhancements to Responsive Navigation:

* [`dev/index.html`](diffhunk://#diff-2be368bc9978a9d56660e9551152a2ecfe068a6b8f9bdae20e46c8a6151676d8R113-R138): Added a new section showcasing the responsive navigation feature, including example code and a carousel setup.
* [`src/responsive-navigation.js`](diffhunk://#diff-a193bedd19fd1d9ced46ff877ac2d7ea36a9ac390fda3085ea2dcecfe556a556L17-R45): Improved the logic to determine if the slider is slide-able by rounding the `slideableWidth` and `innerWidth` values, and added functionality to update the `draggable` option and handle class changes for non-slideable sliders.

### Style Adjustments:

* [`dev/style.scss`](diffhunk://#diff-b4e7365c3652a7304c1d03fc240bc2dbb11626bb9a689c848240e9f7d8c74817L4-R13): Modified the `carousel-cell` class to avoid margin-right for the last child element, ensuring consistent spacing.

### Code Refactoring:

* [`src/_index.js`](diffhunk://#diff-72291d25a221f0b9b4726a864f9525d48063618daa76bd13920da6d4b716de88L25-R27): Updated the default Flickity options to use a more descriptive class name (`isFreeze` instead of `buttonFreeze`) and added a new class for non-slideable elements (`isCannotSlide`).This pull request includes changes to the `src/_index.js` and `src/responsive-navigation.js` files to improve the responsive navigation functionality and add a new class for non-slideable elements.

### Improvements to responsive navigation:

* [`src/_index.js`](diffhunk://#diff-72291d25a221f0b9b4726a864f9525d48063618daa76bd13920da6d4b716de88R27): Added a new class `isCannotSlide` to the `_class` object to handle non-slideable elements.

* [`src/responsive-navigation.js`](diffhunk://#diff-a193bedd19fd1d9ced46ff877ac2d7ea36a9ac390fda3085ea2dcecfe556a556L17-R19): Refactored the calculation of `isSlideable` by rounding `slideableWidth` and `innerWidth` before comparison for better accuracy.

* [`src/responsive-navigation.js`](diffhunk://#diff-a193bedd19fd1d9ced46ff877ac2d7ea36a9ac390fda3085ea2dcecfe556a556R31-R39): Added logic to add or remove the `isCannotSlide` class based on the `isSlideable` condition to visually indicate when elements cannot slide.