### PR TITLE
fix(custom-arrows): add nullish check

### DIFF
--- a/src/custom-arrows.js
+++ b/src/custom-arrows.js
@@ -25,8 +25,8 @@ export function initCustomArrows(flkty, options){
         const arrowInput = options[type];
         const arrowButton = getElement(arrowInput);
 
-        // skip if not a object type
-        if(typeof arrowButton !== 'object') return;
+        // skip if not an object type
+        if(!arrowButton || typeof arrowButton !== 'object') return;
 
         // assign event
         arrowButton.addEventListener('click', () => arrow.func());
@@ -79,15 +79,15 @@ export function updateCustomArrowsDisableStatus(flkty, options){
 
     if(slidePosition === 0){
         // disable prev button
-        prevArrow.setAttribute('disabled', 'disabled');
-        nextArrow.removeAttribute('disabled');
+        prevArrow?.setAttribute('disabled', 'disabled');
+        nextArrow?.removeAttribute('disabled');
     }else if(slidePosition === 1){
         // disable next prev button
-        nextArrow.setAttribute('disabled', 'disabled');
-        prevArrow.removeAttribute('disabled');
+        nextArrow?.setAttribute('disabled', 'disabled');
+        prevArrow?.removeAttribute('disabled');
     }else{
         // remove disable
-        prevArrow.removeAttribute('disabled');
-        nextArrow.removeAttribute('disabled');
+        prevArrow?.removeAttribute('disabled');
+        nextArrow?.removeAttribute('disabled');
     }
 }


### PR DESCRIPTION
This pull request includes changes to improve the robustness and readability of the `custom-arrows.js` file by adding nullish checks and correcting a comment typo.

Improvements to `custom-arrows.js`:

* [`src/custom-arrows.js`](diffhunk://#diff-f97b10ca8bf4b5c0c5847e202ebe36d5063d7339b647b9e90c213d9d99e3d73dL28-R29): Added a nullish check to ensure `arrowButton` is not null or undefined before checking its type in the `initCustomArrows` function.
* [`src/custom-arrows.js`](diffhunk://#diff-f97b10ca8bf4b5c0c5847e202ebe36d5063d7339b647b9e90c213d9d99e3d73dL82-R91): Updated the `updateCustomArrowsDisableStatus` function to use optional chaining for `prevArrow` and `nextArrow` to prevent potential runtime errors if these elements are null or undefined.…is null