### PR TITLE
feat: fix aria hidden focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ const carousel = new FlickityResponsive('.carousel', {
 
     // force move
     forceMove: true, // make sure that every time an arrows clicked, the carousel will move
+
+    // aria hidden focus
+    ariaHiddenFocus: true, // Add tabindex="-1" to all elements with or inside aria-hidden="true"
 });
 ```
 

--- a/src/_index.js
+++ b/src/_index.js
@@ -24,6 +24,7 @@ const defaultFlickityOptions = {
 
     // extra features
     forceMove: true,
+    ariaHiddenFocus: true,
 
     _class: {
         isFreeze: 'is-freeze', // for navigation buttons (prev, next, custom arrows, dots)

--- a/src/aria-hidden-focus.js
+++ b/src/aria-hidden-focus.js
@@ -1,0 +1,14 @@
+/**
+ * ARIA hidden element must not be focusable or contain focusable elements
+ * @description Add tabindex="-1" to all elements with or inside aria-hidden="true"
+ * https://dequeuniversity.com/rules/axe/4.10/aria-hidden-focus
+ */
+export function initAriaHiddenFocus(flkty, options){
+    if(!options.ariaHiddenFocus) return;
+
+    flkty.element.querySelectorAll(`[aria-hidden="true"] a, [aria-hidden="true"] button`).forEach(el => {
+        el.setAttribute('tabindex', '-1');
+
+        el.classList.add('is-focus-disabled');
+    });
+}

--- a/src/on-load.js
+++ b/src/on-load.js
@@ -2,6 +2,7 @@ import {initSlidesIndicator} from "./slides-indicator";
 import {responsiveNavigation} from "./responsive-navigation";
 import {validateWrapAround} from "./helpers";
 import {initForceMove} from "./force-move";
+import {initAriaHiddenFocus} from "./aria-hidden-focus";
 
 export function onLoad(el, options){
     let flkty = Flickity.data(el);
@@ -19,4 +20,7 @@ export function onLoad(el, options){
 
     // one item per slide
     initForceMove(flkty, options);
+
+    // aria hidden focus
+    initAriaHiddenFocus(flkty, options);
 }


### PR DESCRIPTION
This pull request introduces a new feature to manage focusability for elements with `aria-hidden="true"` in the Flickity carousel implementation. The main changes include adding an option to handle ARIA hidden focus and implementing the corresponding functionality.

New feature for ARIA hidden focus:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R128): Added documentation for the new `ariaHiddenFocus` option in the Flickity carousel settings.
* [`src/_index.js`](diffhunk://#diff-72291d25a221f0b9b4726a864f9525d48063618daa76bd13920da6d4b716de88R27): Included the `ariaHiddenFocus` option in the default Flickity options.
* [`src/aria-hidden-focus.js`](diffhunk://#diff-4dcca3792d086d357b6bc8a96b873f702039443074e851b14e53abc72a7c8e6dR1-R14): Created a new module to implement the functionality of adding `tabindex="-1"` to elements with or inside `aria-hidden="true"`.
* [`src/on-load.js`](diffhunk://#diff-cedb414d1ac6b1bacaf1dc430f9f7bf9503e35aed7a0ee5fa4b8456a37664174R5): Imported the `initAriaHiddenFocus` function and called it within the `onLoad` function to initialize the ARIA hidden focus behavior. [[1]](diffhunk://#diff-cedb414d1ac6b1bacaf1dc430f9f7bf9503e35aed7a0ee5fa4b8456a37664174R5) [[2]](diffhunk://#diff-cedb414d1ac6b1bacaf1dc430f9f7bf9503e35aed7a0ee5fa4b8456a37664174R23-R25)