### PR TITLE
feat(onResize): call resize to update flickity layout

### DIFF
--- a/src/on-resize.js
+++ b/src/on-resize.js
@@ -5,6 +5,9 @@ export function onResize(el, options){
     let flkty = Flickity.data(el);
     if(!flkty) return;
 
+    // resize to update flickity layout
+    flkty.resize();
+
     // responsive navigation
     responsiveNavigation(flkty, options);
 


### PR DESCRIPTION
Features related to browser resizing events like `responsiveNavigation` could not be updated correctly on some resize scenarios.

This change call `flkty.resize()` to make sure the Flickity will update the layout.